### PR TITLE
Added matching case for facebook permission request

### DIFF
--- a/webkit/frictionless.safariextension/chrome/content.js
+++ b/webkit/frictionless.safariextension/chrome/content.js
@@ -49,7 +49,8 @@ var appCount = apps.length;
 
 for (var i = 0; i < appCount; i++) {
     if (
-    location.href.indexOf('dialog/permissions.request?app_id=' + apps[i]) + 1
+      (location.href.indexOf('dialog/permissions.request?app_id=' + apps[i]) + 1)
+      || (location.href.indexOf('dialog/oauth?client_id=' + apps[i]) + 1)
     ) {
         var button = document.getElementsByName('cancel_clicked')[0];
         console.info('cancel:', button);


### PR DESCRIPTION
Ran into the case of the facebook permission url at dialog/oauth instead of dialog/permissions.request as I've normally seen.  Added a match check on dialog/oauth
