### PR TITLE
getparams(...) returns the entire URL as a parameter (instead of false) ...

### DIFF
--- a/webkit/frictionless.safariextension/chrome/content.js
+++ b/webkit/frictionless.safariextension/chrome/content.js
@@ -181,7 +181,9 @@ function get_google_redirect_from_title(story_title) {
 
 function get_params(dest_url) {
     dest_url = dest_url.replace(/&amp;/g, '&');
-    var params = dest_url.substr(dest_url.indexOf("?") + 1).split('&'),
+    var query_start = dest_url.indexOf("?") + 1;
+    if(query_start <= 0) return false;
+    var params = dest_url.substr(query_start).split('&'),
     r = {};
     if (typeof params !== 'object' || params.length < 1) return false;
     for (var x = 0; x <= params.length; x++) {


### PR DESCRIPTION
...if there is no query string.  This was causing some URLs to be incorrectly rewritten with an "=" at the end.

See issue #21 (this at least seems to fix the second problem - not sure about the first).

I'll leave version number increment and packaging up to you as I'm not sure if you use a signing key or how you want to increment the version number.
